### PR TITLE
Fix typo in README.md (forge not force)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Of course, this CAN be an issue, especially given `omero-py` _officially_ only s
 it is possible to run `omero-py` in Python 3.8 or newer as well. Our recommended way to do so it using `conda`.
 With conda installed, you can do
 ```
-conda create -n myenv -c conda-force python=3.8 zeroc-ice==3.6.5
+conda create -n myenv -c conda-forge python=3.8 zeroc-ice==3.6.5
 conda activate myenv
 pip install omero-cli-transfer
 ```


### PR DESCRIPTION
Just noticed the install instructions have a typo: `conda-force` instead of `conda-forge`
This is a quick fix, so copy-pasta works!